### PR TITLE
🐛🔨 Fix x86_64 download URLs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,13 +11,7 @@ builds:
     main: ./
     binary: tfautomv
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    format_overrides:
+  - format_overrides:
       - goos: windows
         format: zip
 checksum:


### PR DESCRIPTION
The URLs in the `install.sh` script are wrong. Apparently, they have
been forever. The script itself is sane; what I believe is wrong is our
arbitrary replacements in the `.goreleaser.yaml` file. Let's fix that.
