### PR TITLE
🤖 Run Terraform Cloud e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,10 @@ jobs:
           - 1.0.11
           - 1.1.9
           - 1.2.9
-          - 1.3.9
-          - 1.4.6
-          - 1.5.0
+          - 1.3.10
+          - 1.4.7
+          - 1.5.7
+          - 1.6.4
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false # script interferes with parsing of plan
+          cli_config_credentials_token: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
       - name: Install Terragrunt
         uses: autero1/action-terragrunt@v1.3.2
         with:

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -218,7 +218,7 @@ func TestE2E(t *testing.T) {
 						Count how many changes remain in Terraform's plan.
 					*/
 
-					tf, err := tfexec.NewTerraform(refactoredWorkdir, terraformBin)
+					tf, err = tfexec.NewTerraform(refactoredWorkdir, terraformBin)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -96,8 +96,6 @@ func TestE2E(t *testing.T) {
 			name:        "terraform cloud",
 			workdir:     filepath.Join("testdata", "terraform-cloud"),
 			wantChanges: 0,
-			skip:        true,
-			skipReason:  "tfautomv is currently incompatible with Terraform Cloud workspaces with the \"Remote\" execution mode.\nFor more details, see https://github.com/busser/tfautomv/issues/17",
 		},
 		{
 			name:    "terragrunt",


### PR DESCRIPTION
This PR enables an end-to-end test that uses Terraform Cloud.
Terraform Cloud now supports the `plan` command's `-out` flag,
which allows tfautomv to work with remote workspaces.