### PR TITLE
🐛 Fix data race in end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - 1.4.7
           - 1.5.7
           - 1.6.4
+    concurrency: end-to-end-tests
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
           - 1.4.7
           - 1.5.7
           - 1.6.4
-    concurrency: end-to-end-tests
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4


### PR DESCRIPTION
Most end-to-end tests are stateless, but some are not. For instance,
end-to-end tests that use a Terraform Cloud backend share that backend.
Running multiple instances of these tests concurrently results in data
races and flakiness.

This PR changes our end-to-end tests to ensure we don't change the state
used by these tests. The original state is set up manually beforehand.