### PR TITLE
🐛 Respect --terraform-bin flag in output

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,13 +99,13 @@ func run() error {
 	 * Run `terraform plan` for each working directory provided by the user.
 	 */
 
-	planOptions := []terraform.Option{
+	terraformOptions := []terraform.Option{
 		terraform.WithTerraformBin(terraformBin),
 		terraform.WithSkipInit(skipInit),
 		terraform.WithSkipRefresh(skipRefresh),
 	}
 
-	plans, err := getPlans(ctx, workdirs, planOptions)
+	plans, err := getPlans(ctx, workdirs, terraformOptions)
 	if err != nil {
 		return err
 	}
@@ -153,11 +153,11 @@ func run() error {
 			if err := writeMovedBlocks(sameModule); err != nil {
 				return err
 			}
-			if err := writeMoveCommands(differentModule); err != nil {
+			if err := writeMoveCommands(differentModule, terraformOptions...); err != nil {
 				return err
 			}
 		case !movedBlocksSupported:
-			if err := writeMoveCommands(terraformMoves); err != nil {
+			if err := writeMoveCommands(terraformMoves, terraformOptions...); err != nil {
 				return err
 			}
 		}
@@ -166,7 +166,7 @@ func run() error {
 			return err
 		}
 	case "commands":
-		if err := writeMoveCommands(terraformMoves); err != nil {
+		if err := writeMoveCommands(terraformMoves, terraformOptions...); err != nil {
 			return err
 		}
 	default:
@@ -319,12 +319,12 @@ func writeMovedBlocks(moves []terraform.Move) error {
 	return nil
 }
 
-func writeMoveCommands(moves []terraform.Move) error {
+func writeMoveCommands(moves []terraform.Move, options ...terraform.Option) error {
 	if len(moves) == 0 {
 		return nil
 	}
 
-	err := terraform.WriteMoveCommands(os.Stdout, moves)
+	err := terraform.WriteMoveCommands(os.Stdout, moves, options...)
 	if err != nil {
 		return fmt.Errorf("failed to write move commands: %w", err)
 	}

--- a/pkg/terraform/move.go
+++ b/pkg/terraform/move.go
@@ -84,6 +84,10 @@ func WriteMoveCommands(w io.Writer, moves []Move, opts ...Option) error {
 		return fmt.Errorf("invalid options: %w", err)
 	}
 
+	return writeMoveCommands(w, moves, settings.terraformBin)
+}
+
+func writeMoveCommands(w io.Writer, moves []Move, terraformBin string) error {
 	var commands []string
 
 	// Start with moves within the same module.
@@ -97,7 +101,7 @@ func WriteMoveCommands(w io.Writer, moves []Move, opts ...Option) error {
 
 			commands = append(commands,
 				fmt.Sprintf("%s%s state mv %q %q",
-					settings.terraformBin,
+					terraformBin,
 					chdirFlag,
 					m.FromAddress,
 					m.ToAddress,
@@ -123,7 +127,7 @@ func WriteMoveCommands(w io.Writer, moves []Move, opts ...Option) error {
 	for _, workdir := range workdirs {
 		commands = append(commands,
 			fmt.Sprintf("%s -chdir=%q state pull > %q",
-				settings.terraformBin,
+				terraformBin,
 				workdir,
 				filepath.Join(workdir, localCopyFileName),
 			),
@@ -140,7 +144,7 @@ func WriteMoveCommands(w io.Writer, moves []Move, opts ...Option) error {
 
 		commands = append(commands,
 			fmt.Sprintf("%s state mv -state=%q -state-out=%q %q %q",
-				settings.terraformBin,
+				terraformBin,
 				filepath.Join(move.FromWorkdir, localCopyFileName),
 				filepath.Join(move.ToWorkdir, localCopyFileName),
 				move.FromAddress,
@@ -154,7 +158,7 @@ func WriteMoveCommands(w io.Writer, moves []Move, opts ...Option) error {
 	for _, workdir := range workdirs {
 		commands = append(commands,
 			fmt.Sprintf("%s -chdir=%q state push %q",
-				settings.terraformBin,
+				terraformBin,
 				workdir,
 				localCopyFileName,
 			),
@@ -163,7 +167,7 @@ func WriteMoveCommands(w io.Writer, moves []Move, opts ...Option) error {
 
 	// And we're done.
 
-	_, err = fmt.Fprintln(w, strings.Join(commands, "\n"))
+	_, err := fmt.Fprintln(w, strings.Join(commands, "\n"))
 
 	return err
 }

--- a/pkg/terraform/move_test.go
+++ b/pkg/terraform/move_test.go
@@ -76,9 +76,21 @@ func TestWriteMovedBlocks(t *testing.T) {
 
 func TestWriteMoveCommands(t *testing.T) {
 	tests := []struct {
-		name  string
-		moves []Move
+		name    string
+		moves   []Move
+		options []Option
 	}{
+		{
+			name: "moves within current workdir",
+			moves: []Move{
+				{
+					FromWorkdir: ".",
+					ToWorkdir:   ".",
+					FromAddress: "aws_instance.foo",
+					ToAddress:   "aws_instance.bar",
+				},
+			},
+		},
 		{
 			name: "moves within same workdir",
 			moves: []Move{
@@ -135,13 +147,27 @@ func TestWriteMoveCommands(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "non-default terraform binary",
+			moves: []Move{
+				{
+					FromWorkdir: "/path/to/workdir1",
+					ToWorkdir:   "/path/to/workdir2",
+					FromAddress: "aws_instance.foo",
+					ToAddress:   "aws_instance.bar",
+				},
+			},
+			options: []Option{
+				WithTerraformBin("terragrunt"),
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
 
-			err := WriteMoveCommands(buf, tt.moves)
+			err := WriteMoveCommands(buf, tt.moves, tt.options...)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/terraform/move_test.go
+++ b/pkg/terraform/move_test.go
@@ -167,7 +167,13 @@ func TestWriteMoveCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
 
-			err := WriteMoveCommands(buf, tt.moves, tt.options...)
+			var settings settings
+			settings.apply(append(defaultOptions(), tt.options...))
+
+			// We purposefully don't validate settings here. Whether the
+			// settings are valid depends on the testing environment.
+
+			err := writeMoveCommands(buf, tt.moves, settings.terraformBin)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/terraform/testdata/TestWriteMoveCommands/moves_within_current_workdir.golden
+++ b/pkg/terraform/testdata/TestWriteMoveCommands/moves_within_current_workdir.golden
@@ -1,0 +1,1 @@
+terraform state mv "aws_instance.foo" "aws_instance.bar"

--- a/pkg/terraform/testdata/TestWriteMoveCommands/non-default_terraform_binary.golden
+++ b/pkg/terraform/testdata/TestWriteMoveCommands/non-default_terraform_binary.golden
@@ -1,0 +1,5 @@
+terragrunt -chdir="/path/to/workdir1" state pull > "/path/to/workdir1/.tfautomv.tfstate"
+terragrunt -chdir="/path/to/workdir2" state pull > "/path/to/workdir2/.tfautomv.tfstate"
+terragrunt state mv -state="/path/to/workdir1/.tfautomv.tfstate" -state-out="/path/to/workdir2/.tfautomv.tfstate" "aws_instance.foo" "aws_instance.bar"
+terragrunt -chdir="/path/to/workdir1" state push ".tfautomv.tfstate"
+terragrunt -chdir="/path/to/workdir2" state push ".tfautomv.tfstate"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -45,6 +45,11 @@ resource "random_pet" "refactored_third" {
 }
 
 func TestE2E_OutputBlocks(t *testing.T) {
+	tfVersion := terraformVersion(t)
+	if tfVersion.LessThan(version.Must(version.NewVersion("1.1"))) {
+		t.Skip("tfautomv requires Terraform 1.6 or later to run this test")
+	}
+
 	workdir := t.TempDir()
 	codePath := filepath.Join(workdir, "main.tf")
 
@@ -331,17 +336,6 @@ resource "random_pet" "refactored_third" {
 	terragruntConfig := `
 inputs = {
 	prefix = "my-"
-}
-generate "backend" {
-	path      = "backend.tf"
-	if_exists = "overwrite"
-	contents = <<EOF
-terraform {
-	backend "local" {
-		path = "non-standard-path.tfstate"
-	}
-}
-EOF
 }`
 
 	writeCode(t, codePath, originalCode)

--- a/test/e2e/test_utils.go
+++ b/test/e2e/test_utils.go
@@ -143,7 +143,7 @@ func terragruntPlan(t *testing.T, workdir string) *tfjson.Plan {
 	return runPlan(t, workdir, terragruntBin)
 }
 
-func runTfautomv(t *testing.T, workdir string, args []string) {
+func runTfautomv(t *testing.T, workdir string, args []string) string {
 	t.Helper()
 
 	tfautomvBinAbsPath, err := filepath.Abs(tfautomvBin)
@@ -165,9 +165,7 @@ func runTfautomv(t *testing.T, workdir string, args []string) {
 		t.Fatalf("tfautomv failed: %v", err)
 	}
 
-	if stdout.Len() > 0 {
-		runShellCommands(t, workdir, stdout.String())
-	}
+	return stdout.String()
 }
 
 func runShellCommands(t *testing.T, workdir string, commands string) {
@@ -183,6 +181,16 @@ func runShellCommands(t *testing.T, workdir string, commands string) {
 	t.Log("Running shell commands")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("shell commands failed: %v", err)
+	}
+}
+
+func runTfautomvPipeSh(t *testing.T, workdir string, args []string) {
+	t.Helper()
+
+	commands := runTfautomv(t, workdir, args)
+
+	if commands != "" {
+		runShellCommands(t, workdir, commands)
 	}
 }
 


### PR DESCRIPTION
Fixes #70.

Adds end-to-end tests for the different output formats.

Removes an extra space from generated commands when the target workspace
is the current working directory.