### PR TITLE
feat: Run tfautomv against a plan file

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,16 @@ environment variable to any value:
 NO_COLOR=true tfautomv
 ```
 
+### Disabling colors in output
+
+Add the `--plan-path` flag to your `tfautomv` skip running a terraform init and plan and instead use an already generated terraform json plan.
+
+For example:
+
+```bash
+tfautomv --plan-path ./plan.json
+```
+
 ## Thanks
 
 Thanks to [Padok](https://www.padok.fr), where this project was born 💜

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Generate Terraform `moved` blocks automatically.
   - [Passing additional arguments to Terraform](#passing-additional-arguments-to-terraform)
   - [Using Terragrunt instead of Terraform](#using-terragrunt-instead-of-terraform)
   - [Disabling colors in output](#disabling-colors-in-output)
+  - [Run tfautomv against a plan file](#run-tfautomv-against-a-plan-file)
 - [Thanks](#thanks)
 - [License](#license)
 
@@ -424,7 +425,7 @@ environment variable to any value:
 NO_COLOR=true tfautomv
 ```
 
-### Disabling colors in output
+### Run tfautomv against a plan file
 
 Add the `--plan-path` flag to your `tfautomv` skip running a terraform init and plan and instead use an already generated terraform json plan.
 

--- a/main.go
+++ b/main.go
@@ -95,9 +95,10 @@ func run() error {
 	}
 
 	/*
-	 * Step 2: Obtain Terraform plan
+	 * Step 2: Obtain Terraform plan if no plan file paths given
 	 *
 	 * Run `terraform plan` for each working directory provided by the user.
+	 * If plan file paths given read it in.
 	 */
 
 	terraformOptions := []terraform.Option{
@@ -116,8 +117,11 @@ func run() error {
 	} else {
 		for _, planPath := range planPaths {
 			jsonPlan, err := terraform.GetPlanFromPath(planPath)
-			stringSlice := strings.Split(planPath, "/")
-			moduleID := strings.Join(stringSlice[:len(stringSlice)-1], "/")
+			if err != nil {
+				return err
+			}
+			planPathSplit := strings.Split(planPath, "/")
+			moduleID := strings.Join(planPathSplit[:len(planPathSplit)-1], "/")
 			plan, err := engine.SummarizeJSONPlan(moduleID, jsonPlan)
 			if err != nil {
 				return err

--- a/pkg/terraform/plan.go
+++ b/pkg/terraform/plan.go
@@ -51,3 +51,20 @@ func GetPlan(ctx context.Context, opts ...Option) (*tfjson.Plan, error) {
 
 	return plan, nil
 }
+
+func GetPlanFromPath(p string) (*tfjson.Plan, error) {
+	data, err := ioutil.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the JSON data into a Plan struct
+	var plan terraform.Plan
+	err = json.Unmarshal(data, &plan)
+	if err != nil {
+		return nil, err
+	}
+
+	return &plan, nil
+
+}

--- a/pkg/terraform/plan.go
+++ b/pkg/terraform/plan.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -53,13 +54,13 @@ func GetPlan(ctx context.Context, opts ...Option) (*tfjson.Plan, error) {
 }
 
 func GetPlanFromPath(p string) (*tfjson.Plan, error) {
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return nil, err
 	}
 
 	// Unmarshal the JSON data into a Plan struct
-	var plan terraform.Plan
+	var plan tfjson.Plan
 	err = json.Unmarshal(data, &plan)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Implementing this [feature request](https://github.com/busser/tfautomv/issues/78)

I have been using this to refactor TFE workspaces that cannot be planned locally but where I can download the json plan file after TFE has remotely planned it.
