### PR TITLE
feat: add Terragrunt version matrix testing to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,16 +75,53 @@ jobs:
       - name: Run OpenTofu-specific tests
         run: go test ./test/e2e -run TestE2E_OpenTofu -v
 
+  end-to-end-tests-terragrunt:
+    name: End-to-End Tests (Terragrunt)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terragrunt-version:
+          - 0.74.10
+          - 0.75.12
+          - 0.76.8
+          - 0.77.4
+          - 0.78.7
+          - 0.79.5
+          - 0.80.4
+          - 0.81.10
+          - 0.82.4
+          - 0.83.1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.4
+          terraform_wrapper: false
+      - name: Install Terragrunt
+        uses: autero1/action-terragrunt@v3.0.2
+        with:
+          terragrunt-version: ${{ matrix.terragrunt-version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: make build
+      - name: Run Terragrunt-specific tests
+        run: go test ./test/e2e -run TestE2E_Terragrunt -v
+
   end-to-end-tests-check:
     name: End-to-End Tests (matrix)
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [end-to-end-tests, end-to-end-tests-opentofu]
+    needs: [end-to-end-tests, end-to-end-tests-opentofu, end-to-end-tests-terragrunt]
     steps:
       - run: |
           terraform_result="${{ needs.end-to-end-tests.result }}"
           opentofu_result="${{ needs.end-to-end-tests-opentofu.result }}"
-          if [[ $terraform_result == "success" || $terraform_result == "skipped" ]] && [[ $opentofu_result == "success" || $opentofu_result == "skipped" ]]; then
+          terragrunt_result="${{ needs.end-to-end-tests-terragrunt.result }}"
+          if [[ $terraform_result == "success" || $terraform_result == "skipped" ]] && [[ $opentofu_result == "success" || $opentofu_result == "skipped" ]] && [[ $terragrunt_result == "success" || $terragrunt_result == "skipped" ]]; then
             exit 0
           else
             exit 1


### PR DESCRIPTION
## Summary
- Add `end-to-end-tests-terragrunt` job to test tfautomv compatibility across 10 Terragrunt versions (0.74.10 to 0.83.1)
- Mirror the existing OpenTofu test matrix structure
- Update `end-to-end-tests-check` to validate all three test matrices (Terraform, OpenTofu, Terragrunt)

## Test plan
- [x] Added Terragrunt version matrix with 10 versions covering 0.74.x to 0.83.x
- [x] Job runs `TestE2E_Terragrunt` test for each Terragrunt version
- [x] Updated matrix validation to include Terragrunt results
- [ ] Wait for CI to run and verify test infrastructure works
- [ ] Address any test failures (expected for newer versions per issue #105)

This establishes the testing infrastructure for systematic Terragrunt compatibility testing without fixing any underlying compatibility issues.

🤖 Generated with [Claude Code](https://claude.ai/code)