### PR TITLE
feat: add json rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,8 +432,25 @@ tfautomv --ignore="prefix:google_storage_bucket_iam_member:bucket:b/"
 ```
 
 will strip the `b/` prefix from the `bucket` attribute of any
-`google_storage_bucket_iam_member` resources before comparing the attirbute's
+`google_storage_bucket_iam_member` resources before comparing the attribute's
 values.
+
+#### The `json` kind
+
+Use the `json` kind to ignore string differences for equivalent JSON:
+
+```bash
+tfautomv --ignore="json:<RESOURCE TYPE>:<ATTRIBUTE NAME>"
+```
+
+For example:
+
+```bash
+tfautomv --ignore="json:local_file:content"
+```
+
+will compare the JSON representation of the `content` attribute of any `local_file`
+resources instead of the raw strings.
 
 #### Referencing nested attributes
 

--- a/pkg/engine/rules/json.go
+++ b/pkg/engine/rules/json.go
@@ -1,0 +1,63 @@
+package rules
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type jsonRule struct {
+	baseRule
+}
+
+func parseJSONRule(s string) (*jsonRule, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return nil, errors.New("syntax error")
+	}
+
+	r := jsonRule{
+		baseRule: baseRule{
+			resourceType: parts[0],
+			attribute:    parts[1],
+		},
+	}
+
+	return &r, nil
+}
+
+func (r jsonRule) String() string {
+	return fmt.Sprintf("%s:%s:%s", RuleTypeJSON, r.resourceType, r.attribute)
+}
+
+func (r *jsonRule) Equates(a, b interface{}) bool {
+	aVal := reflect.ValueOf(a)
+	bVal := reflect.ValueOf(b)
+
+	if aVal.Kind() != bVal.Kind() {
+		return false
+	}
+	kind := aVal.Kind()
+
+	var aStr, bStr string
+	if kind == reflect.String {
+		aStr = aVal.String()
+		bStr = bVal.String()
+	} else {
+		aStr = fmt.Sprint(a)
+		bStr = fmt.Sprint(b)
+	}
+
+	var aJSON, bJSON interface{}
+	err := json.Unmarshal([]byte(aStr), &aJSON)
+	if err != nil {
+		return false
+	}
+	err = json.Unmarshal([]byte(bStr), &bJSON)
+	if err != nil {
+		return false
+	}
+	return reflect.DeepEqual(aJSON, bJSON)
+}

--- a/pkg/engine/rules/json_test.go
+++ b/pkg/engine/rules/json_test.go
@@ -1,0 +1,111 @@
+package rules
+
+import "testing"
+
+func TestJSONRuleAppliesTo(t *testing.T) {
+	rule := jsonRule{
+		baseRule{
+			resourceType: "my_resource",
+			attribute:    "my_attr",
+		},
+	}
+
+	tests := []struct {
+		resourceType string
+		attribute    string
+		want         bool
+	}{
+		{
+			resourceType: "my_resource",
+			attribute:    "my_attr",
+			want:         true,
+		},
+		{
+			resourceType: "not_my_resource",
+			attribute:    "my_attr",
+			want:         false,
+		},
+		{
+			resourceType: "my_resource",
+			attribute:    "not_my_attr",
+			want:         false,
+		},
+		{
+			resourceType: "not_my_resource",
+			attribute:    "not_my_attr",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		actual := rule.AppliesTo(tt.resourceType, tt.attribute)
+		if actual != tt.want {
+			t.Errorf("AppliesTo(%q, %q) = %t, want %t", tt.resourceType, tt.attribute, actual, tt.want)
+		}
+	}
+}
+
+func TestJSONRuleEquates(t *testing.T) {
+	tests := []struct {
+		valueA interface{}
+		valueB interface{}
+		prefix string
+		want   bool
+	}{
+		{
+			valueA: "foo",
+			valueB: "foo",
+			want:   false,
+		},
+		{
+			valueA: `"foo"`,
+			valueB: `"foo"`,
+			want:   true,
+		},
+		{
+			valueA: "[1,2,3]",
+			valueB: "[1,2,3]",
+			want:   true,
+		},
+		{
+			valueA: "[1,2,3]",
+			valueB: "[1,3,2]",
+			want:   false,
+		},
+		{
+			valueA: `{"foo": "bar", "baz": "qux"}`,
+			valueB: `{"baz": "qux", "foo": "bar"}`,
+			want:   true,
+		},
+		{
+			valueA: `{"foo": {"list": [1,2,3], "object": {"nested": true}}}`,
+			valueB: `{
+        "foo": {
+          "object": {
+            "nested": true
+          },
+         "list": [
+            1,
+            2,
+            3
+          ]
+        }
+      }`,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		rule := jsonRule{
+			baseRule{
+				resourceType: "my_resource",
+				attribute:    "my_attr",
+			},
+		}
+
+		actual := rule.Equates(tt.valueA, tt.valueB)
+		if actual != tt.want {
+			t.Errorf("Equates(%q, %q) = %t, want %t", tt.valueA, tt.valueB, actual, tt.want)
+		}
+	}
+}

--- a/pkg/engine/rules/parse.go
+++ b/pkg/engine/rules/parse.go
@@ -22,6 +22,9 @@ const (
 	// RuleTypeWhitespace ignores differences in whitespace between two
 	// attributes' values. Whitespace is as defined by unicode.IsSpace.
 	RuleTypeWhitespace RuleType = "whitespace"
+
+	// RuleTypeJSON ignores differences in JSON representation.
+	RuleTypeJSON RuleType = "json"
 )
 
 // Parse converts a string into a Rule.
@@ -40,6 +43,8 @@ func Parse(s string) (engine.Rule, error) {
 		return parsePrefixRule(parts[1])
 	case RuleTypeWhitespace:
 		return parseWhitespaceRule(parts[1])
+	case RuleTypeJSON:
+		return parseJSONRule(parts[1])
 	default:
 		return nil, fmt.Errorf("unknown rule type %q", ruleType)
 	}


### PR DESCRIPTION
This PR adds the `json` kind as an ignore rule. This rule parses JSON in resource attributes and, if valid, compares the parsed objects. I personally used it for refactoring ElasticSearch objects where templates and policies are stored in JSON. I found that example too unusual to use it in the docs, so I simply used `local_file` there.

Currently, when the object cannot be parsed as JSON, the rule simply returns `false`. It could be better to resort to string comparison, but I'm not sure what the expected behavior would be.